### PR TITLE
src/Tools.php

### DIFF
--- a/src/Tools.php
+++ b/src/Tools.php
@@ -697,7 +697,7 @@ class Tools extends ToolsCommon
      * @param  string $chave
      * @return string
      */
-    public function sefazDownload($chave)
+    public function sefazDownload($chave, $fonte = 'AN')
     {
         //carrega serviço
         $servico = 'NfeDistribuicaoDFe';


### PR DESCRIPTION
Enquanto desenvolvia uma aplicação encontrei uma variável não definida na função sefazDownload($chave), a variável fica na linha 707 é a $fonte, declarei ela na função , a função ficou da seguinte maneira sefazDownload($chave, $fonte = 'AN')